### PR TITLE
tiny fix

### DIFF
--- a/src/System/Build.hs
+++ b/src/System/Build.hs
@@ -12,7 +12,7 @@ data BuildTarget = SimpleTarget String
                  | FullTarget String String
 
 asStackArg :: BuildTarget -> String
-asStackArg (SimpleTarget t)    = "exe:" ++ t
+asStackArg (SimpleTarget t)    = ":" ++ t
 asStackArg (FullTarget pref t) = pref ++ ":exe:" ++ t
 
 asBinaryName :: BuildTarget -> String


### PR DESCRIPTION
according to docs (https://docs.haskellstack.org/en/stable/build_command/), `:compname` pattern can be used  but i don't see anything about `comptype:compname` pattern in the docs. It also returns error with the latter one. Did it work like this before? (perhaps this pattern is outdated now?)